### PR TITLE
Add multiple working copy paths with tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+config.json

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -164,6 +164,98 @@ body {
 }
 
 /* ==========================================================================
+   Working Copy Tabs
+   ========================================================================== */
+
+.working-copy-tabs {
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    margin-bottom: var(--spacing-lg);
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+}
+
+.tabs-container {
+    display: flex;
+    align-items: center;
+    padding: var(--spacing-sm);
+    gap: var(--spacing-sm);
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
+.tabs-list {
+    display: flex;
+    gap: var(--spacing-xs);
+    flex: 1;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: var(--spacing-xs) 0;
+}
+
+.tab-button {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: var(--transition);
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    min-height: 32px;
+}
+
+.tab-button:hover {
+    background: var(--bg-secondary);
+    border-color: var(--border-dark);
+    color: var(--text-primary);
+}
+
+.tab-button.active {
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+    color: white;
+    font-weight: 500;
+}
+
+.tab-button.active:hover {
+    background: var(--primary-hover);
+    border-color: var(--primary-hover);
+}
+
+.tab-refresh {
+    flex-shrink: 0;
+}
+
+.tab-refresh i {
+    font-size: 0.875rem;
+}
+
+/* Scrollbar styling for tabs */
+.tabs-list::-webkit-scrollbar {
+    height: 6px;
+}
+
+.tabs-list::-webkit-scrollbar-track {
+    background: var(--bg-tertiary);
+    border-radius: var(--radius-sm);
+}
+
+.tabs-list::-webkit-scrollbar-thumb {
+    background: var(--border-dark);
+    border-radius: var(--radius-sm);
+}
+
+.tabs-list::-webkit-scrollbar-thumb:hover {
+    background: var(--secondary-color);
+}
+
+/* ==========================================================================
    Controls Bar
    ========================================================================== */
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,6 +47,18 @@
                 </div>
             </div>
 
+            <!-- Working Copy Tabs -->
+            <div id="workingCopyTabs" class="working-copy-tabs" style="display: none;">
+                <div class="tabs-container">
+                    <div id="tabsList" class="tabs-list">
+                        <!-- Tabs will be dynamically inserted here -->
+                    </div>
+                    <button id="refreshTabsBtn" class="tab-button tab-refresh" title="Refresh working copies">
+                        <i class="fas fa-sync-alt"></i>
+                    </button>
+                </div>
+            </div>
+
             <!-- Search and Filters -->
             <div class="controls-bar">
                 <div class="search-box">
@@ -176,8 +188,22 @@
             <div class="modal-body">
                 <form id="settingsForm">
                     <div class="form-group">
+                        <label for="projectsDirectoryInput">
+                            <i class="fas fa-folder-open"></i> Projects Directory
+                        </label>
+                        <div class="input-with-button">
+                            <input type="text" id="projectsDirectoryInput" class="form-control"
+                                   placeholder="/path/to/projects">
+                            <button type="button" id="setProjectsDirectoryBtn" class="btn btn-secondary">
+                                Set Directory
+                            </button>
+                        </div>
+                        <small class="form-help">Directory containing multiple SVN working copies - all subdirectories with .svn folders will appear as tabs</small>
+                    </div>
+
+                    <div class="form-group">
                         <label for="workingCopyInput">
-                            <i class="fas fa-folder"></i> Working Copy Path
+                            <i class="fas fa-folder"></i> Single Working Copy Path (Optional)
                         </label>
                         <div class="input-with-button">
                             <input type="text" id="workingCopyInput" class="form-control"
@@ -186,7 +212,7 @@
                                 Set Path
                             </button>
                         </div>
-                        <small class="form-help">Path to your SVN working copy directory</small>
+                        <small class="form-help">Use this if you want to work with a single working copy without using the projects directory</small>
                     </div>
 
                     <div class="form-group">


### PR DESCRIPTION
Features:
- Set a projects directory containing multiple SVN working copies
- Automatically discover all subdirectories with .svn folders
- Display discovered working copies as tabs above the filter controls
- Click tabs to quickly switch between projects
- Refresh button to rescan projects directory
- Active tab is highlighted in blue
- Working copies sorted alphabetically by name

Implementation:
- Backend: Added discover_working_copies() function to scan directories
- Backend: New API endpoints for managing working copies:
  - GET /api/working-copies - List all discovered working copies
  - POST /api/working-copies/projects-directory - Set projects directory
  - POST /api/working-copies/activate - Switch active working copy
- Backend: Config migration from old 'working_copy_path' to new format
- Frontend: Added tab UI component with horizontal scroll support
- Frontend: Added JavaScript for loading and switching working copies
- Frontend: Updated settings modal with projects directory input
- CSS: Styled tabs with active state and hover effects
- Added config.json to .gitignore (user-specific configuration)

The single working copy path option is still supported for backward compatibility, but the primary workflow is now projects directory based.