### PR TITLE
Add SHIFT modifier to toggle between Properties and Externals mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -440,9 +440,11 @@ def api_open_tortoisesvn_properties():
 
     Body:
         parent_path: The path of the folder containing svn:externals
+        open_externals: Boolean, if True opens the externals-specific editor
     """
     data = request.json
     parent_path = data.get('parent_path')
+    open_externals = data.get('open_externals', False)
 
     if not parent_path:
         return jsonify({
@@ -453,7 +455,7 @@ def api_open_tortoisesvn_properties():
     manager = get_svn_manager()
 
     try:
-        success, message = manager.open_tortoisesvn_properties(parent_path)
+        success, message = manager.open_tortoisesvn_properties(parent_path, open_externals)
 
         return jsonify({
             'success': success,

--- a/svn_manager.py
+++ b/svn_manager.py
@@ -626,12 +626,13 @@ class SVNManager:
         # If not found in common paths, assume it's in PATH
         return "TortoiseProc.exe"
 
-    def open_tortoisesvn_properties(self, parent_path: str) -> Tuple[bool, str]:
+    def open_tortoisesvn_properties(self, parent_path: str, open_externals: bool = False) -> Tuple[bool, str]:
         """
         Open TortoiseSVN properties dialog for a specific path.
 
         Args:
             parent_path: The path of the folder containing the svn:externals property
+            open_externals: If True, opens the externals-specific property editor
 
         Returns:
             Tuple of (success, message)
@@ -650,6 +651,7 @@ class SVNManager:
         # Debug logging
         print(f"DEBUG: parent_path received: '{parent_path}'")
         print(f"DEBUG: working_copy_path: '{self.working_copy_path}'")
+        print(f"DEBUG: open_externals: {open_externals}")
 
         # Build full path and normalize it (converts forward slashes to backslashes on Windows)
         full_path = os.path.normpath(os.path.join(self.working_copy_path, parent_path))
@@ -668,6 +670,10 @@ class SVNManager:
                 "/command:properties",
                 f'/path:"{full_path}"'
             ]
+
+            # Add /property:svn:externals to open externals-specific editor
+            if open_externals:
+                cmd_parts.append("/property:svn:externals")
 
             cmd_string = ' '.join(cmd_parts)
             print(f"Executing TortoiseSVN command: {cmd_string}")


### PR DESCRIPTION
When the user holds SHIFT while hovering over or clicking the Properties button, it dynamically changes to "Externals" mode which opens the TortoiseSVN properties dialog with the svn:externals editor directly.

Frontend changes:
- Track shift key state globally (shiftKeyPressed)
- Add keydown/keyup listeners to detect SHIFT key
- Re-render table when SHIFT state changes
- Update button text: "Properties" -> "Externals" when SHIFT held
- Update button icon: fa-cog -> fa-external-link-alt when SHIFT held
- Pass open_externals parameter to API based on SHIFT state

Backend changes:
- Add open_externals parameter to API endpoint
- Update open_tortoisesvn_properties() to accept open_externals flag
- Add /property:svn:externals parameter when open_externals is True
- Add debug logging for open_externals parameter

User experience:
- Normal click: Opens general properties dialog
- SHIFT + click: Opens properties with externals tab focused
- Button text/icon changes in real-time as SHIFT is pressed/released