### PR TITLE
Add support for nested SVN externals with hierarchical display

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -343,7 +343,15 @@ body {
 .data-table {
     width: 100%;
     border-collapse: collapse;
+    table-layout: fixed;
 }
+
+/* Column widths: Name/Path + URL ≈ 75%, rest ≈ 25% */
+.data-table th:nth-child(1) { width: 30%; }  /* Name/Path */
+.data-table th:nth-child(2) { width: 7%; }   /* Revision */
+.data-table th:nth-child(3) { width: 38%; }  /* URL */
+.data-table th:nth-child(4) { width: 8%; }   /* Status */
+.data-table th:nth-child(5) { width: 17%; }  /* Actions */
 
 .data-table thead {
     background: var(--bg-tertiary);
@@ -398,23 +406,29 @@ body {
 .data-table td {
     padding: var(--spacing-md);
     vertical-align: middle;
+    overflow: hidden;
 }
 
 .data-table td:last-child {
     white-space: nowrap;
-    min-width: 10rem;
 }
 
 .external-name {
     font-weight: 500;
     color: var(--text-primary);
     margin-bottom: var(--spacing-xs);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .external-path {
     font-size: 0.75rem;
     color: var(--text-secondary);
     font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .change-details {
@@ -459,7 +473,6 @@ body {
 }
 
 .external-url {
-    max-width: 400px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -343,7 +343,6 @@ body {
 .data-table {
     width: 100%;
     border-collapse: collapse;
-    table-layout: fixed;
 }
 
 .data-table thead {
@@ -357,11 +356,6 @@ body {
     font-weight: 600;
     color: var(--text-primary);
     white-space: nowrap;
-    width: 1%; /* shrink-to-fit by default; Name/Path overrides below */
-}
-
-.data-table th:first-child {
-    width: auto; /* Name/Path absorbs remaining space and truncates first */
 }
 
 .data-table th.sortable {
@@ -414,18 +408,12 @@ body {
     font-weight: 500;
     color: var(--text-primary);
     margin-bottom: var(--spacing-xs);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .external-path {
     font-size: 0.75rem;
     color: var(--text-secondary);
     font-family: var(--font-mono);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .change-details {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -400,6 +400,10 @@ body {
     vertical-align: middle;
 }
 
+.data-table td:last-child {
+    white-space: nowrap;
+}
+
 .external-name {
     font-weight: 500;
     color: var(--text-primary);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -400,6 +400,11 @@ body {
     vertical-align: middle;
 }
 
+.data-table td:first-child {
+    max-width: 0;
+    overflow: hidden;
+}
+
 .data-table td:last-child {
     white-space: nowrap;
 }
@@ -408,12 +413,18 @@ body {
     font-weight: 500;
     color: var(--text-primary);
     margin-bottom: var(--spacing-xs);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .external-path {
     font-size: 0.75rem;
     color: var(--text-secondary);
     font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .change-details {
@@ -458,7 +469,7 @@ body {
 }
 
 .external-url {
-    max-width: 400px;
+    max-width: 300px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -423,6 +423,36 @@ body {
     font-weight: 500;
 }
 
+/* ==========================================================================
+   Nested Externals
+   ========================================================================== */
+
+.nested-external {
+    background-color: rgba(0, 0, 0, 0.015);
+}
+
+.nested-external:hover {
+    background-color: rgba(0, 0, 0, 0.035);
+}
+
+.nested-depth-1 td:first-child {
+    padding-left: calc(var(--spacing-md) + 1.5rem);
+}
+
+.nested-depth-2 td:first-child {
+    padding-left: calc(var(--spacing-md) + 3rem);
+}
+
+.nested-depth-3 td:first-child {
+    padding-left: calc(var(--spacing-md) + 4.5rem);
+}
+
+.nesting-indicator {
+    color: var(--text-light);
+    margin-right: var(--spacing-xs);
+    font-size: 0.8rem;
+}
+
 .external-url {
     max-width: 400px;
     overflow: hidden;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -400,31 +400,21 @@ body {
     vertical-align: middle;
 }
 
-.data-table td:first-child {
-    max-width: 0;
-    overflow: hidden;
-}
-
 .data-table td:last-child {
     white-space: nowrap;
+    min-width: 10rem;
 }
 
 .external-name {
     font-weight: 500;
     color: var(--text-primary);
     margin-bottom: var(--spacing-xs);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .external-path {
     font-size: 0.75rem;
     color: var(--text-secondary);
     font-family: var(--font-mono);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .change-details {
@@ -469,7 +459,7 @@ body {
 }
 
 .external-url {
-    max-width: 300px;
+    max-width: 400px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -343,6 +343,7 @@ body {
 .data-table {
     width: 100%;
     border-collapse: collapse;
+    table-layout: fixed;
 }
 
 .data-table thead {
@@ -356,6 +357,11 @@ body {
     font-weight: 600;
     color: var(--text-primary);
     white-space: nowrap;
+    width: 1%; /* shrink-to-fit by default; Name/Path overrides below */
+}
+
+.data-table th:first-child {
+    width: auto; /* Name/Path absorbs remaining space and truncates first */
 }
 
 .data-table th.sortable {
@@ -408,12 +414,18 @@ body {
     font-weight: 500;
     color: var(--text-primary);
     margin-bottom: var(--spacing-xs);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .external-path {
     font-size: 0.75rem;
     color: var(--text-secondary);
     font-family: var(--font-mono);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .change-details {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -561,7 +561,7 @@ function renderTable() {
         if (hasRevisionChange) {
             viewLogButton = `
                 <button class="btn btn-sm btn-primary" onclick="viewChangelog('${escapeHtml(external.url)}', '${escapeHtml(oldRev)}', '${escapeHtml(newRev)}', '${escapeHtml(external.name)}')">
-                    <i class="fas fa-list"></i> View Changes
+                    <i class="fas fa-list"></i> Changelog
                 </button>
             `;
         } else {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -441,6 +441,67 @@ async function loadExternals() {
 }
 
 /**
+ * Build a grouped list of externals where nested externals appear right after their parent.
+ * Top-level externals are sorted by the current sort column; nested children follow their parent.
+ */
+function buildGroupedList(data) {
+    const sortFn = (a, b) => {
+        const aVal = a[currentSort.column] || '';
+        const bVal = b[currentSort.column] || '';
+        if (currentSort.ascending) {
+            return aVal.toString().localeCompare(bVal.toString());
+        } else {
+            return bVal.toString().localeCompare(aVal.toString());
+        }
+    };
+
+    // Separate top-level and nested externals
+    const topLevel = [];
+    const childrenMap = {}; // parent_external path -> [children]
+
+    for (const ext of data) {
+        if (!ext.depth || !ext.parent_external) {
+            topLevel.push(ext);
+        } else {
+            if (!childrenMap[ext.parent_external]) {
+                childrenMap[ext.parent_external] = [];
+            }
+            childrenMap[ext.parent_external].push(ext);
+        }
+    }
+
+    // Sort top-level externals
+    topLevel.sort(sortFn);
+
+    // Build final list: each parent followed by its sorted children (recursively)
+    const result = [];
+    const added = new Set();
+
+    function addWithChildren(ext) {
+        result.push(ext);
+        added.add(ext.path);
+        const children = childrenMap[ext.path] || [];
+        children.sort(sortFn);
+        for (const child of children) {
+            addWithChildren(child);
+        }
+    }
+
+    for (const ext of topLevel) {
+        addWithChildren(ext);
+    }
+
+    // Append any orphaned nested externals (parent filtered out)
+    for (const ext of data) {
+        if (!added.has(ext.path)) {
+            result.push(ext);
+        }
+    }
+
+    return result;
+}
+
+/**
  * Render the externals table
  */
 function renderTable() {
@@ -457,17 +518,8 @@ function renderTable() {
         return;
     }
 
-    // Sort data
-    const sortedData = [...filteredData].sort((a, b) => {
-        const aVal = a[currentSort.column] || '';
-        const bVal = b[currentSort.column] || '';
-
-        if (currentSort.ascending) {
-            return aVal.toString().localeCompare(bVal.toString());
-        } else {
-            return bVal.toString().localeCompare(aVal.toString());
-        }
-    });
+    // Sort and group data (nested externals stay under their parent)
+    const sortedData = buildGroupedList(filteredData);
 
     // Render rows
     tableBody.innerHTML = sortedData.map(external => {
@@ -535,10 +587,14 @@ function renderTable() {
             `;
         }
 
+        const depth = external.depth || 0;
+        const depthClass = depth > 0 ? ` nested-external nested-depth-${Math.min(depth, 3)}` : '';
+        const nestingIndicator = depth > 0 ? '<span class="nesting-indicator">\u21b3</span>' : '';
+
         return `
-            <tr class="external-row status-${statusClass}" data-path="${external.path}">
+            <tr class="external-row status-${statusClass}${depthClass}" data-path="${external.path}">
                 <td>
-                    <div class="external-name">${escapeHtml(external.name)}</div>
+                    <div class="external-name">${nestingIndicator}${escapeHtml(external.name)}</div>
                     <div class="external-path">${escapeHtml(external.path)}</div>
                     ${changeDetailsHTML}
                 </td>

--- a/svn_manager.py
+++ b/svn_manager.py
@@ -71,20 +71,26 @@ class SVNManager:
 
                 # Determine status based on definition changes
                 external['status'], external['change_details'] = self._get_external_status(external, base_external)
+                external['depth'] = 0
+                external['parent_external'] = None
                 externals.append(external)
+
+            # Collect nested externals (externals within externals)
+            externals = self._collect_nested_externals(externals)
 
         except subprocess.SubprocessError as e:
             print(f"Error getting externals: {e}")
 
         return externals
 
-    def _get_externals_from_propget(self, path: str, pristine: bool = False) -> List[Dict]:
+    def _get_externals_from_propget(self, path: str, pristine: bool = False, cwd: str = None) -> List[Dict]:
         """
         Get externals from svn propget command.
 
         Args:
             path: Path to query
             pristine: If True, get BASE (pristine) version, otherwise get working version
+            cwd: Working directory for the SVN command (defaults to self.working_copy_path)
 
         Returns:
             List of external definitions
@@ -102,7 +108,7 @@ class SVNManager:
                 capture_output=True,
                 text=True,
                 timeout=30,
-                cwd=self.working_copy_path
+                cwd=cwd or self.working_copy_path
             )
 
             if result.returncode != 0:
@@ -292,6 +298,90 @@ class SVNManager:
         except Exception as e:
             print(f"Error getting external status: {e}")
             return 'error', None
+
+    def _collect_nested_externals(self, externals: List[Dict], max_depth: int = 5) -> List[Dict]:
+        """
+        Recursively collect nested externals (externals defined within externals).
+
+        For each external that has a checked-out directory with its own svn:externals,
+        this method discovers those nested definitions and inserts them right after
+        their parent in the returned list.
+
+        Args:
+            externals: List of external dicts (must already have 'depth' and 'parent_external' set)
+            max_depth: Maximum nesting depth to prevent infinite recursion
+
+        Returns:
+            New list with nested externals inserted after their parents
+        """
+        result = []
+
+        for external in externals:
+            result.append(external)
+
+            if external['depth'] >= max_depth:
+                continue
+
+            # Check if the external's checkout directory exists and is an SVN working copy
+            ext_full_path = os.path.join(self.working_copy_path, external['path'])
+            svn_dir = os.path.join(ext_full_path, '.svn')
+
+            if not os.path.isdir(ext_full_path) or not os.path.isdir(svn_dir):
+                continue
+
+            try:
+                # Get working and BASE externals from the nested working copy
+                nested_working = self._get_externals_from_propget(
+                    ext_full_path, pristine=False, cwd=ext_full_path
+                )
+                nested_base = self._get_externals_from_propget(
+                    ext_full_path, pristine=True, cwd=ext_full_path
+                )
+
+                # Adjust paths for both working and base to be relative to the main working copy
+                for ext in nested_working:
+                    if ext['parent_path'] == '.':
+                        ext['parent_path'] = external['path']
+                    else:
+                        ext['parent_path'] = os.path.join(external['path'], ext['parent_path'])
+                    ext['path'] = os.path.join(external['path'], ext['path'])
+
+                for ext in nested_base:
+                    if ext['parent_path'] == '.':
+                        ext['parent_path'] = external['path']
+                    else:
+                        ext['parent_path'] = os.path.join(external['path'], ext['parent_path'])
+                    ext['path'] = os.path.join(external['path'], ext['path'])
+
+                # Build base lookup (after path adjustment so keys match)
+                nested_base_lookup = {}
+                for ext in nested_base:
+                    key = f"{ext['parent_path']}:{ext['name']}"
+                    nested_base_lookup[key] = ext
+
+                # Process nested working externals
+                nested_externals = []
+                for nested_ext in nested_working:
+                    key = f"{nested_ext['parent_path']}:{nested_ext['name']}"
+                    nested_base_ext = nested_base_lookup.get(key)
+
+                    nested_ext['status'], nested_ext['change_details'] = self._get_external_status(
+                        nested_ext, nested_base_ext
+                    )
+                    nested_ext['depth'] = external['depth'] + 1
+                    nested_ext['parent_external'] = external['path']
+
+                    nested_externals.append(nested_ext)
+
+                # Recursively collect deeper nested externals
+                if nested_externals:
+                    nested_externals = self._collect_nested_externals(nested_externals, max_depth)
+                    result.extend(nested_externals)
+
+            except Exception as e:
+                print(f"Error collecting nested externals for {external['path']}: {e}")
+
+        return result
 
     def get_changed_externals(self) -> List[Dict]:
         """


### PR DESCRIPTION
## Summary
This PR adds support for discovering and displaying nested SVN externals (externals defined within externals) in the UI. Nested externals are now shown hierarchically under their parent external with visual indentation and nesting indicators.

Resolves #9

## Key Changes

**Backend (svn_manager.py):**
- Added `_collect_nested_externals()` method to recursively discover externals within externals up to a configurable depth limit
- Modified `_get_externals_from_propget()` to accept an optional `cwd` parameter for querying nested working copies
- Each external now includes `depth` (nesting level) and `parent_external` (parent path) metadata
- Nested externals are inserted immediately after their parent in the results list

**Frontend (app.js):**
- Added `buildGroupedList()` function to organize externals hierarchically while maintaining sort order at each level
- Top-level externals are sorted by the current sort column; nested children follow their parent
- Modified `renderTable()` to use the grouped list and apply depth-based styling
- Changed "View Changes" button label to "Changelog" for consistency

**Styling (style.css):**
- Added `.data-table td:last-child` rule to prevent text wrapping in the last column
- Added nested external styling with subtle background color changes on hover
- Implemented depth-based left padding (`.nested-depth-1/2/3`) for visual hierarchy
- Added `.nesting-indicator` styling for the arrow symbol (↳) that precedes nested external names

## Implementation Details
- Nested externals are discovered by checking if each external's checkout directory contains a `.svn` folder and querying its `svn:externals` property
- Maximum nesting depth is configurable (default: 5 levels) to prevent infinite recursion
- Paths are automatically adjusted so nested externals are displayed relative to the main working copy
- The grouping preserves sort order at each level while maintaining parent-child relationships

https://claude.ai/code/session_01EGwo1BYvuGjRxLFmGtGckj